### PR TITLE
Updated link for 213 TA to F23 instance of the course.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,7 @@
 
 <h3>Teaching</h3>
 <ul>
-    <li><a href="https://www.cs.cmu.edu/~213/staff.html">Teaching Assistant for 15-213 (F23)</a></li>
+    <li><a href="https://www.cs.cmu.edu/afs/cs/academic/class/15213-f23/www/staff.html">Teaching Assistant for 15-213 (F23)</a></li>
     <li><a href="http://www.cs.cmu.edu/~112-n23/">Teaching Assistant for 15-112 &mdash; QA Lead (N23)</a></li>
     <li><a href="http://www.cs.cmu.edu/~112-s23/">Teaching Assistant for 15-112 (S23)</a></li>
     <li><a href="http://www.cs.cmu.edu/~112-f22/">Teaching Assistant for 15-112 (F22)</a></li>


### PR DESCRIPTION
## Subject: Enhance User Experience: Update Link for More Specific Course Materials

Hi everyone,

This PR refines a link in our documentation to provide a more specific and relevant user experience. 

Currently, the link for "[Course Name]" (or course ID 15213) directs users to a generic course page. This update tailors the link to point directly to the F23 instance of the course materials.

**Benefits:**

* Improved user experience: Users will be taken straight to the F23 course materials, saving them time and avoiding unnecessary navigation.
* Increased efficiency: Users will have quicker access to the specific information they need.
* Enhanced clarity: The updated link clearly indicates the F23 instance, reducing confusion.

**Changes:**

* The link for "[Course Name]" (or course ID 15213) in [Location of Link] will be updated to point directly to the F23 instance of the course.

**Testing:**

* After merging this PR, please verify that the link in [Location of Link] leads users to the F23 instance of the "[Course Name]" (or course ID 15213) materials.

This update demonstrates our commitment to user-friendliness and providing efficient access to information.

Please review this PR and let me know if you have any questions.

Thanks,
Anna